### PR TITLE
Remove intermediate .unifiler folder

### DIFF
--- a/engine/metadata.go
+++ b/engine/metadata.go
@@ -560,7 +560,7 @@ func (m *MetadataModule) saveHResults(ctx *db.DbContext, hResults []*core.FileMu
 
 // Return database path to store Metadata module's ouputs inside Unifiler workspace.
 func MetadataWorkspaceDatabase(workspaceDir string) string {
-	return filepath.Join(workspaceDir, ".unifiler", "metadata.db")
+	return filepath.Join(workspaceDir, "metadata.db")
 }
 
 // Define Cobra Command for Metadata module.

--- a/engine/mirror.go
+++ b/engine/mirror.go
@@ -202,7 +202,7 @@ func (m *MirrorModule) logError(err error) {
 
 // Return directory path to store Mirror module's ouputs inside Unifiler workspace.
 func MirrorWorkspaceRoot(workspaceDir string) string {
-	return filepath.Join(workspaceDir, ".unifiler", "mirror")
+	return filepath.Join(workspaceDir, "mirror")
 }
 
 // Define Cobra Command for Mirror module.


### PR DESCRIPTION
This PR removes the the intermediately folder for MetadataModule and MirrorModule for better Workspace path clarity.