### PR TITLE
New official name: TFunifiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# TF Unifiler
+# TFunifiler
 
-Go implementation of T-Force Universal File Operator, a cross-platform file management solution.
+T-Force Universal File Operator, cross-platform file management solution.
 
 ## License
 
-TF Unifiler is licensed under GPL-3.0 license. See COPYING file for more details. TF Unifiler is developed using the following libraries and frameworks:
+TFunifiler is licensed under GPL-3.0 license. See [COPYING](COPYING) file for details. TFunifiler is developed using the following libraries and frameworks:
 
 - [nullable](https://github.com/tee8z/nullable) library, Copyright 2020 Athaariq Ardhiansyah. Licensed under MIT license.
 
-TF Unifiler Build Library is licensed under LGPL-3.0 license. See COPYING.LESSER file for more details. Please notice that a portion of TF Unifiler Build Library is a modified version of the following libraries:
+TFunifiler Build Library is licensed under LGPL-3.0 license. See [COPYING.LESSER](COPYING.LESSER) file for details. Please notice that a portion of TFunifiler Build Library is a modified version of the following libraries:
 
 - [The go-ethereum](https://github.com/ethereum/go-ethereum) library, Copyright 2016 The go-ethereum Authors. Licensed under LGPL-3.0 license.

--- a/build/ci.go
+++ b/build/ci.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler Build library.
+// This file is part of TFunifiler Build library.
 //
-// TF Unifiler Build library is free software: you can redistribute it and/or modify
+// TFunifiler Build library is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler Build library is distributed in the hope that it will be useful,
+// TFunifiler Build library is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with TF Unifiler Build library. If not, see <http://www.gnu.org/licenses/>.
+// along with TFunifiler Build library. If not, see <http://www.gnu.org/licenses/>.
 //
 // This file is a modified version of The go-ethereum library, Copyright 2016 The go-ethereum Authors
 
@@ -27,7 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/tforceaio/tf-unifiler-go/filesys"
+	"github.com/tforceaio/tf-unifiler/filesys"
 )
 
 var GOBIN, _ = filepath.Abs(".bin")
@@ -116,7 +116,7 @@ func buildFlags(env Environment, staticLinking bool, buildTags []string) (flags 
 	// cgo-linker further down.
 	ld = append(ld, "--buildid=none")
 
-	mainPackage := "github.com/tforceaio/tf-unifiler-go/engine"
+	mainPackage := "github.com/tforceaio/tf-unifiler/engine"
 	if env.Commit != "" {
 		ld = append(ld, "-X", mainPackage+".gitCommit="+fmt.Sprintf("%.8s", env.Commit))
 		ld = append(ld, "-X", mainPackage+".gitDate="+env.Date)

--- a/build/env.go
+++ b/build/env.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler Build library.
+// This file is part of TFunifiler Build library.
 //
-// TF Unifiler Build library is free software: you can redistribute it and/or modify
+// TFunifiler Build library is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler Build library is distributed in the hope that it will be useful,
+// TFunifiler Build library is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with TF Unifiler Build library. If not, see <http://www.gnu.org/licenses/>.
+// along with TFunifiler Build library. If not, see <http://www.gnu.org/licenses/>.
 //
 // This file is a modified version of The go-ethereum library, Copyright 2016 The go-ethereum Authors
 

--- a/build/git.go
+++ b/build/git.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler Build library.
+// This file is part of TFunifiler Build library.
 //
-// TF Unifiler Build library is free software: you can redistribute it and/or modify
+// TFunifiler Build library is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler Build library is distributed in the hope that it will be useful,
+// TFunifiler Build library is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with TF Unifiler Build library. If not, see <http://www.gnu.org/licenses/>.
+// along with TFunifiler Build library. If not, see <http://www.gnu.org/licenses/>.
 //
 // This file is a modified version of The go-ethereum library, Copyright 2016 The go-ethereum Authors
 

--- a/build/go.go
+++ b/build/go.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler Build library.
+// This file is part of TFunifiler Build library.
 //
-// TF Unifiler Build library is free software: you can redistribute it and/or modify
+// TFunifiler Build library is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler Build library is distributed in the hope that it will be useful,
+// TFunifiler Build library is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with TF Unifiler Build library. If not, see <http://www.gnu.org/licenses/>.
+// along with TFunifiler Build library. If not, see <http://www.gnu.org/licenses/>.
 //
 // This file is a modified version of The go-ethereum library, Copyright 2016 The go-ethereum Authors
 

--- a/build/os.go
+++ b/build/os.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler Build library.
+// This file is part of TFunifiler Build library.
 //
-// TF Unifiler Build library is free software: you can redistribute it and/or modify
+// TFunifiler Build library is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler Build library is distributed in the hope that it will be useful,
+// TFunifiler Build library is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with TF Unifiler Build library. If not, see <http://www.gnu.org/licenses/>.
+// along with TFunifiler Build library. If not, see <http://www.gnu.org/licenses/>.
 //
 // This file is a modified version of The go-ethereum library, Copyright 2016 The go-ethereum Authors
 

--- a/config/koanf.go
+++ b/config/koanf.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package config
 
@@ -27,7 +27,7 @@ import (
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/providers/structs"
 	"github.com/knadh/koanf/v2"
-	"github.com/tforceaio/tf-unifiler-go/filesys"
+	"github.com/tforceaio/tf-unifiler/filesys"
 )
 
 // Singleton instance of configuration.

--- a/config/koanf_test.go
+++ b/config/koanf_test.go
@@ -1,25 +1,25 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package config
 
 import (
 	"testing"
 
-	"github.com/tforceaio/tf-unifiler-go/filesys"
+	"github.com/tforceaio/tf-unifiler/filesys"
 )
 
 func TestFileConfig(t *testing.T) {

--- a/config/readme.go
+++ b/config/readme.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 /*
 Package config contains initialization code for logging, and reading configuration

--- a/config/types.go
+++ b/config/types.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package config
 

--- a/config/zerolog.go
+++ b/config/zerolog.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package config
 
@@ -25,7 +25,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/tforce-io/tf-golib/opx"
-	"github.com/tforceaio/tf-unifiler-go/filesys"
+	"github.com/tforceaio/tf-unifiler/filesys"
 )
 
 // Entrypoint for creating a ZeroLog logger instance.

--- a/core/types.go
+++ b/core/types.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package core
 

--- a/db/archive.go
+++ b/db/archive.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 

--- a/db/archive_content.go
+++ b/db/archive_content.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 

--- a/db/archive_content_test.go
+++ b/db/archive_content_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 

--- a/db/archive_test.go
+++ b/db/archive_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 

--- a/db/dbcontext.go
+++ b/db/dbcontext.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/glebarez/sqlite"
-	"github.com/tforceaio/tf-unifiler-go/filesys"
+	"github.com/tforceaio/tf-unifiler/filesys"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )

--- a/db/dbcontext_test.go
+++ b/db/dbcontext_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 

--- a/db/hash.go
+++ b/db/hash.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 
@@ -20,17 +20,17 @@ import (
 	"encoding/hex"
 
 	"github.com/google/uuid"
-	"github.com/tforceaio/tf-unifiler-go/core"
+	"github.com/tforceaio/tf-unifiler/core"
 )
 
 // Hash represents a set of hashes for a particular file along with basic metadata.
 type Hash struct {
-	ID     Bytes32   `gorm:"column:id;primaryKey"`
-	Md5    string    `gorm:"column:md5"`
-	Sha1   string    `gorm:"column:sha1"`
-	Sha256 string    `gorm:"column:sha256;uniqueIndex"`
-	Sha512 string    `gorm:"column:sha512"`
-	Crc32  string    `gorm:"column:crc32"`
+	ID     Bytes32 `gorm:"column:id;primaryKey"`
+	Md5    string  `gorm:"column:md5"`
+	Sha1   string  `gorm:"column:sha1"`
+	Sha256 string  `gorm:"column:sha256;uniqueIndex"`
+	Sha512 string  `gorm:"column:sha512"`
+	Crc32  string  `gorm:"column:crc32"`
 
 	Size        uint32 `gorm:"column:size"`
 	Description string `gorm:"column:description"`

--- a/db/hash_test.go
+++ b/db/hash_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 

--- a/db/mapping.go
+++ b/db/mapping.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 

--- a/db/mapping_test.go
+++ b/db/mapping_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 

--- a/db/session.go
+++ b/db/session.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 

--- a/db/set.go
+++ b/db/set.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 

--- a/db/set_hash.go
+++ b/db/set_hash.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 

--- a/db/set_hash_test.go
+++ b/db/set_hash_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 

--- a/db/set_test.go
+++ b/db/set_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 

--- a/db/types.go
+++ b/db/types.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package db
 

--- a/encoding/checksum/checksum_test.go
+++ b/encoding/checksum/checksum_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package checksum
 
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tforceaio/tf-unifiler-go/xlib"
+	"github.com/tforceaio/tf-unifiler/xlib"
 )
 
 func TestParseMd5Error(t *testing.T) {

--- a/encoding/checksum/scanner_test.go
+++ b/encoding/checksum/scanner_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package checksum
 

--- a/encoding/checksum/sfv.go
+++ b/encoding/checksum/sfv.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package checksum
 

--- a/encoding/checksum/sfv_test.go
+++ b/encoding/checksum/sfv_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package checksum
 
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tforceaio/tf-unifiler-go/xlib"
+	"github.com/tforceaio/tf-unifiler/xlib"
 )
 
 func TestPParseCRC32ItemCount(t *testing.T) {

--- a/encoding/checksum/types.go
+++ b/encoding/checksum/types.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package checksum
 

--- a/engine/checksum.go
+++ b/engine/checksum.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package engine
 
@@ -26,7 +26,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/tforce-io/tf-golib/opx"
-	"github.com/tforceaio/tf-unifiler-go/filesys"
+	"github.com/tforceaio/tf-unifiler/filesys"
 )
 
 // ChecksumModule handles user requests related checksum file creation and verification.

--- a/engine/common_filesys.go
+++ b/engine/common_filesys.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package engine
 
@@ -22,8 +22,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/tforceaio/tf-unifiler-go/crypto/hasher"
-	"github.com/tforceaio/tf-unifiler-go/filesys"
+	"github.com/tforceaio/tf-unifiler/crypto/hasher"
+	"github.com/tforceaio/tf-unifiler/filesys"
 )
 
 // fileHashResult pairs a filesystem entry with its computed hashes.

--- a/engine/common_log.go
+++ b/engine/common_log.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package engine
 

--- a/engine/common_validator.go
+++ b/engine/common_validator.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package engine
 
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/tforceaio/tf-unifiler-go/filesys"
+	"github.com/tforceaio/tf-unifiler/filesys"
 )
 
 // Check for non empty input and its existence on disk.

--- a/engine/controller.go
+++ b/engine/controller.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package engine
 
@@ -20,7 +20,7 @@ import (
 	"os"
 
 	"github.com/rs/zerolog"
-	"github.com/tforceaio/tf-unifiler-go/config"
+	"github.com/tforceaio/tf-unifiler/config"
 )
 
 // Controller is the entrypoint for working with application configurations and

--- a/engine/file.go
+++ b/engine/file.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package engine
 
@@ -25,7 +25,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/tforce-io/tf-golib/opx"
-	"github.com/tforceaio/tf-unifiler-go/filesys"
+	"github.com/tforceaio/tf-unifiler/filesys"
 )
 
 // Struct FileRenameMapping stores old and new filename after renaming for rollback.

--- a/engine/main.go
+++ b/engine/main.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package engine
 
@@ -25,8 +25,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tforce-io/tf-golib/opx"
-	"github.com/tforceaio/tf-unifiler-go/filesys"
-	"github.com/tforceaio/tf-unifiler-go/filesys/exec"
+	"github.com/tforceaio/tf-unifiler/filesys"
+	"github.com/tforceaio/tf-unifiler/filesys/exec"
 )
 
 var majorVersion = 0
@@ -71,7 +71,7 @@ func InitApp() *Controller {
 	exec, _ := os.Executable()
 	exec, _ = filesys.GetAbsPath(exec)
 
-	cfg.Logger.Info().Msgf("TF UNIFILER v%s", version())
+	cfg.Logger.Info().Msgf("TFunifiler v%s", version())
 	gitDate2, _ := time.Parse("20060102", gitDate)
 	buildDate := opx.Ternary(gitDate == "", time.Now().UTC(), gitDate2)
 	cfg.Logger.Info().Msgf("Copyright (C) %d T-Force I/O", buildDate.Year())
@@ -93,7 +93,7 @@ func Execute() {
 	rootCmd := &cobra.Command{
 		Use: "unifiler",
 		Long: fmt.Sprintf(
-			`TF UNIFILER v%s.
+			`TFunifiler v%s.
 Copyright (C) %d T-Force I/O.
 Licensed under GPL-3.0 license. See COPYING file along with this program for more details.`,
 			version(),

--- a/engine/main_test.go
+++ b/engine/main_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package engine
 
@@ -25,7 +25,7 @@ import (
 
 	"github.com/tforce-io/tf-golib/multiarch"
 	"github.com/tforce-io/tf-golib/opx"
-	"github.com/tforceaio/tf-unifiler-go/db"
+	"github.com/tforceaio/tf-unifiler/db"
 )
 
 func getTestDB(entity, function string) *db.DbContext {

--- a/engine/metadata.go
+++ b/engine/metadata.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package engine
 
@@ -30,9 +30,9 @@ import (
 	"github.com/tforce-io/tf-golib/opx"
 	"github.com/tforce-io/tf-golib/opx/slicext"
 	"github.com/tforce-io/tf-golib/strfmt"
-	"github.com/tforceaio/tf-unifiler-go/core"
-	"github.com/tforceaio/tf-unifiler-go/db"
-	"github.com/tforceaio/tf-unifiler-go/filesys"
+	"github.com/tforceaio/tf-unifiler/core"
+	"github.com/tforceaio/tf-unifiler/db"
+	"github.com/tforceaio/tf-unifiler/filesys"
 )
 
 // MetadataModule handles user requests related file hashes.

--- a/engine/metadata_test.go
+++ b/engine/metadata_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package engine
 
@@ -22,8 +22,8 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/tforce-io/tf-golib/stdx"
-	"github.com/tforceaio/tf-unifiler-go/core"
-	"github.com/tforceaio/tf-unifiler-go/db"
+	"github.com/tforceaio/tf-unifiler/core"
+	"github.com/tforceaio/tf-unifiler/db"
 )
 
 func TestFileSaveHResults(t *testing.T) {

--- a/engine/mirror.go
+++ b/engine/mirror.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package engine
 
@@ -26,8 +26,8 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/tforce-io/tf-golib/opx"
-	"github.com/tforceaio/tf-unifiler-go/encoding/checksum"
-	"github.com/tforceaio/tf-unifiler-go/filesys"
+	"github.com/tforceaio/tf-unifiler/encoding/checksum"
+	"github.com/tforceaio/tf-unifiler/filesys"
 )
 
 // Struct FileMirrorMapping stores old and new filename after mirroring for rollback.

--- a/engine/readme.go
+++ b/engine/readme.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 /*
 Package engine is the core of the program. It wires up logic from other packages

--- a/engine/video.go
+++ b/engine/video.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package engine
 
@@ -28,10 +28,10 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/tforce-io/tf-golib/opx"
-	"github.com/tforceaio/tf-unifiler-go/config"
-	"github.com/tforceaio/tf-unifiler-go/filesys"
-	"github.com/tforceaio/tf-unifiler-go/filesys/exec"
-	"github.com/tforceaio/tf-unifiler-go/internal/nullable"
+	"github.com/tforceaio/tf-unifiler/config"
+	"github.com/tforceaio/tf-unifiler/filesys"
+	"github.com/tforceaio/tf-unifiler/filesys/exec"
+	"github.com/tforceaio/tf-unifiler/internal/nullable"
 )
 
 // VideoModule handles user requests related to batch processing of video files.

--- a/filesys/directory.go
+++ b/filesys/directory.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package filesys
 

--- a/filesys/directory_test.go
+++ b/filesys/directory_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package filesys
 

--- a/filesys/exec/exec.go
+++ b/filesys/exec/exec.go
@@ -1,25 +1,25 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package exec
 
 import (
 	"os/exec"
 
-	"github.com/tforceaio/tf-unifiler-go/xlib"
+	"github.com/tforceaio/tf-unifiler/xlib"
 )
 
 type CommandArgs interface {

--- a/filesys/exec/ffmpeg.go
+++ b/filesys/exec/ffmpeg.go
@@ -1,25 +1,25 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package exec
 
 import (
 	"strconv"
 
-	"github.com/tforceaio/tf-unifiler-go/internal/nullable"
+	"github.com/tforceaio/tf-unifiler/internal/nullable"
 )
 
 type FFmpegArgs struct {

--- a/filesys/exec/logger.go
+++ b/filesys/exec/logger.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package exec
 

--- a/filesys/exec/mediainfo.go
+++ b/filesys/exec/mediainfo.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package exec
 

--- a/filesys/exec/mediainfo_report.go
+++ b/filesys/exec/mediainfo_report.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package exec
 

--- a/filesys/exec/mediainfo_test.go
+++ b/filesys/exec/mediainfo_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package exec
 

--- a/filesys/file.go
+++ b/filesys/file.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package filesys
 

--- a/filesys/file_test.go
+++ b/filesys/file_test.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package filesys
 

--- a/filesys/logger.go
+++ b/filesys/logger.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package filesys
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tforceaio/tf-unifiler-go
+module github.com/tforceaio/tf-unifiler
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -1,22 +1,22 @@
 // Copyright (C) 2025 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package main
 
-import "github.com/tforceaio/tf-unifiler-go/engine"
+import "github.com/tforceaio/tf-unifiler/engine"
 
 func main() {
 	engine.Execute()

--- a/xlib/error.go
+++ b/xlib/error.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package xlib
 

--- a/xlib/json.go
+++ b/xlib/json.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package xlib
 

--- a/xlib/zerolog.go
+++ b/xlib/zerolog.go
@@ -1,18 +1,18 @@
 // Copyright (C) 2024 T-Force I/O
-// This file is part of TF Unifiler
+// This file is part of TFunifiler
 //
-// TF Unifiler is free software: you can redistribute it and/or modify
+// TFunifiler is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// TF Unifiler is distributed in the hope that it will be useful,
+// TFunifiler is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with TF Unifiler. If not, see <https://www.gnu.org/licenses/>.
+// along with TFunifiler. If not, see <https://www.gnu.org/licenses/>.
 
 package xlib
 


### PR DESCRIPTION
The application will now be known as TFunifiler.

Remove -go suffix in package name. Only go version of the application is available.